### PR TITLE
Add decay to tangential considering zero as radiusline

### DIFF
--- a/algorithims/potential_fields/fields.py
+++ b/algorithims/potential_fields/fields.py
@@ -235,7 +235,7 @@ class TangentialField(PotentialField):
         if radius_max and to_taget_scalar > radius_max:
             return (0, 0)
 
-        to_target_scalar_norm = max(0, min(1, to_taget_scalar/self.radius))
+        to_target_scalar_norm = max(0, min(1, abs((self.radius - to_taget_scalar)/self.radius_max)))
         end_angle = 0
         if to_taget_scalar > self.radius:
             end_angle = angle_to_target + cwo * (math.pi/2) * (2 - ( (self.radius + self.K)/(to_taget_scalar + self.K) ))

--- a/strategy/tests/Idle.py
+++ b/strategy/tests/Idle.py
@@ -6,15 +6,6 @@ from commons.math import unit_vector
 import json
 import numpy as np
 
-def point_in_rect(point,rect):
-    x1, y1, w, h = rect
-    x2, y2 = x1+w, y1+h
-    x, y = point
-    if (x1 < x and x < x2):
-        if (y1 < y and y < y2):
-            return True
-    return False
-
 class Idle(Strategy):
     def __init__(self, match):
         super().__init__(match)


### PR DESCRIPTION
O campo tangencial é um pouco diferente dos campos de linha e ponto:

Enquanto os dois anteriores tem um espaço onde o robo, idealmente para (centro do raio ou na linha descrita, respectivamente) o campo tangencial geralmente se espera que na linha do raio onde ele atua ele continue se movendo (para ficar girando). Nesse caso, julguei que seria melhor que o a função de caimento funcionasse em relação a distancia que o robo esta do raio, invés do centro do raio (como no point line por exemplo).

Isso foi reforçado pq, hoje o campo tangencial só funcionaria bem se mantivesse velocidade constante, e isso é um problema considerando as recentes mudanças do simulador (velocidades constantes geram paradas bruscas que, com o robo mais alto, estão fazendo o robo capotar).

Aproveitei e delete um metodo no arquivo Idle.py, nao esta sendo usado para nada