### PR TITLE
Correção quando implementação de send_replacement nao é feita

### DIFF
--- a/blue_team.json
+++ b/blue_team.json
@@ -1,5 +1,5 @@
 {
-    "referee": false,
+    "referee": true,
     "data_sender": true,
     "network" : {
         "multicast_ip": "224.0.0.1",

--- a/main.py
+++ b/main.py
@@ -69,10 +69,11 @@ class Game():
             self.comm.send(commands)
             
             if self.referee.get_foul() != "STOP" and self.referee.get_foul() != None:
-                self.referee.send_replacement(
-                    self.match.coach.get_positions( self.referee.get_foul(), self.referee.get_color() ),
-                    self.match.team_color.upper()
-                )
+                if self.match.coach.get_positions( self.referee.get_foul(), self.referee.get_color() ):
+                    self.referee.send_replacement(
+                        self.match.coach.get_positions( self.referee.get_foul(), self.referee.get_color() ),
+                        self.match.team_color.upper()
+                    )
             
         if self.use_data_sender:
             api.DataSender().send_data()


### PR DESCRIPTION
Caso algum coach opte por manter o comportamento padrão do Referee, é importante que o código não quebre, dessa forma, coloquei um pequeno fix, caso get_positions retornar ```None``` então o Game não devera enviar o comando de replacing.

Isso ainda pode quebrar caso o Coach não tenha o metodo ```get_positions``` mas isso sera corrigido no futuro, quando Coach tiver uma classe abstrata que tera a referencia do metodo e com um comportamento padrão de enviar sempre None, ou seja, se vc nao implementar nao tem problema