### PR TITLE
Base Coach

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "match" : {
         "num_robots": 3,
         "team_color": "blue",
-        "coach_name": "LARC2020Coach",
+        "coach_name": "LARC_2020",
         "category": "3v3"
     },
     "referee": true,

--- a/entities/coach/__init__.py
+++ b/entities/coach/__init__.py
@@ -1,3 +1,14 @@
+from entities.coach.coach import BaseCoach
+
 from entities.coach.larc2020 import Coach as LarcCoach
 from entities.coach.iron2021 import Coach as IronCoach
 from entities.coach.experiment_astar import Coach as AstarCoach
+
+_coach_list = [
+    LarcCoach,
+    IronCoach,
+    AstarCoach
+]
+
+
+COACHES = {c.NAME: c for c in _coach_list}

--- a/entities/coach/coach.py
+++ b/entities/coach/coach.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+
+class BaseCoach(ABC):
+    NAME = "BASE_COACH"
+    def __init__(self, match):
+        self.match = match
+
+    @abstractmethod
+    def decide (self):
+        raise NotImplementedError("Coach needs decide implementation!")
+
+    def get_positions(self, foul, team_color):
+        return None

--- a/entities/coach/experiment_astar.py
+++ b/entities/coach/experiment_astar.py
@@ -2,8 +2,9 @@ from entities.coach.coach import BaseCoach
 import strategy
 
 class Coach(BaseCoach):
+    NAME = "EXPERIMENTAL_COACH_ASTAR"
     def __init__(self, match):
-        super().__init__(match, "Experiment-astar")
+        super().__init__(match)
         self.test_strategy = strategy.tests.AstarAttacker(self.match)
 
         self.idle_strategy = [

--- a/entities/coach/experiment_astar.py
+++ b/entities/coach/experiment_astar.py
@@ -1,10 +1,9 @@
-import algorithms
+from entities.coach.coach import BaseCoach
 import strategy
 
-class Coach(object):
+class Coach(BaseCoach):
     def __init__(self, match):
-        self.match = match
-
+        super().__init__(match, "Experiment-astar")
         self.test_strategy = strategy.tests.AstarAttacker(self.match)
 
         self.idle_strategy = [

--- a/entities/coach/iron2021.py
+++ b/entities/coach/iron2021.py
@@ -1,14 +1,9 @@
-import algorithms
-import strategy
+from entities.coach.coach import BaseCoach
 from entities import plays
-import math
-import time
 
-from commons.math import angular_speed, speed, rotate_via_numpy, unit_vector
-
-class Coach(object):
+class Coach(BaseCoach):
     def __init__(self, match):
-        self.match = match
+        super().__init__(match, "IRON-2021")
 
         self.playbook = plays.Playbook(self)
 

--- a/entities/coach/iron2021.py
+++ b/entities/coach/iron2021.py
@@ -2,8 +2,9 @@ from entities.coach.coach import BaseCoach
 from entities import plays
 
 class Coach(BaseCoach):
+    NAME = "IRON_2021"
     def __init__(self, match):
-        super().__init__(match, "IRON-2021")
+        super().__init__(match)
 
         self.playbook = plays.Playbook(self)
 

--- a/entities/coach/larc2020.py
+++ b/entities/coach/larc2020.py
@@ -4,8 +4,9 @@ import math
 import json
 
 class Coach(BaseCoach):
+    NAME = "LARC_2020"
     def __init__(self, match):
-        super().__init__(match, "LARC-2020")
+        super().__init__(match)
 
         self.constraints = [
             #estratégia - função eleitora - prioridade

--- a/entities/coach/larc2020.py
+++ b/entities/coach/larc2020.py
@@ -1,12 +1,12 @@
-import algorithms
+from entities.coach.coach import BaseCoach
 import strategy
 import math
-from commons.math import angular_speed, speed, rotate_via_numpy, unit_vector
 import json
 
-class Coach(object):
+class Coach(BaseCoach):
     def __init__(self, match):
-        self.match = match
+        super().__init__(match, "LARC-2020")
+
         self.constraints = [
             #estratégia - função eleitora - prioridade
             (strategy.larc2020.GoalKeeper(self.match), self.elect_goalkeeper, 0),

--- a/match/match.py
+++ b/match/match.py
@@ -1,14 +1,7 @@
 import os
 import entities
-import algorithms
 
 from concurrent import futures
-
-AVAILABLE_COACHES = {
-    'LARC2020Coach': entities.coach.LarcCoach,
-    'Iron2021Coach': entities.coach.IronCoach,
-    'Astar': entities.coach.AstarCoach
-}
 
 class Match(object):
     def __init__(self, game, team_color, num_robots=3, coach_name=None, category="3v3"):
@@ -33,7 +26,7 @@ class Match(object):
             entities.Robot(self.game, i, self.team_color) for i in range(self.n_robots)
         ]
 
-        self.coach = AVAILABLE_COACHES[self.coach_name](self)
+        self.coach = entities.coach.COACHES[self.coach_name](self)
         self.coach.decide()
 
         for robot in self.robots:

--- a/match/match.py
+++ b/match/match.py
@@ -16,6 +16,7 @@ class Match(object):
 
     
     def start(self):
+        print("Starting match module starting ...")
         self.ball = entities.Ball(self.game)
 
         self.opposites = [
@@ -27,6 +28,7 @@ class Match(object):
         ]
 
         self.coach = entities.coach.COACHES[self.coach_name](self)
+        print(f"Match started! coach is [{self.coach.NAME}]")
         self.coach.decide()
 
         for robot in self.robots:

--- a/yellow_team.json
+++ b/yellow_team.json
@@ -14,7 +14,7 @@
     "match" : {
         "num_robots": 3,
         "team_color": "yellow",
-        "coach_name": "LARC2020Coach",
+        "coach_name": "LARC_2020",
         "category": "3v3"
     }
 }


### PR DESCRIPTION
Esse PR tem duas implementações principais que estão relacionadas a facilitar a criação de Coaches no NeonFC

* Criação de uma classe abstrata, chamada ```BaseCoach```. Nela teremos pre-implementado os métodos que os outros módulos podem garantir que existem e podem ser chamados, como ```decide``` e ```get_positions```. Isso nos dará mais tranquilidade para implementar outras coisas sem ter medo de quebrar tudo.

* Dentro do construtor do Coach agora existe um dicionario que faz o mesmo que aquele AVAILABLES_COACHES que havia no match, considerando que alem de feio, AVAILABLES_COACHES ficar no match.py nao fazia muito sentido. Dessa forma agora a chave de texto para usar coaches fica concentrada na variável estática NAME, dentro de cada classe coach que será criada.

Além disso, algumas pequenas mudanças que não mudam o comportamento.


Como essas mudanças foram feitas objetivando facilitar a criação de estratégias desde o começo, fiz junto a elas [essa documentação](https://github.com/project-neon/NeonFC/wiki/guia-de-colaboracao---criar-um-coach-basico) (outras poderão vir, acredito que possamos inclusive fazer de forma coletiva).
