### PR TITLE
DebugPotentialFieldStrategy

### DIFF
--- a/algorithms/potential_fields/__init__.py
+++ b/algorithms/potential_fields/__init__.py
@@ -1,1 +1,2 @@
 import algorithms.potential_fields.fields
+import algorithms.potential_fields.plotter

--- a/algorithms/potential_fields/fields.py
+++ b/algorithms/potential_fields/fields.py
@@ -9,10 +9,7 @@ MIN_WEIGHT_ACTIVE = 0.0
 
 def call_or_return(func, match_context, robot_id=-1):
     if callable(func):
-        if func.__code__.co_argcount == 1:
-            return func(match_context)
-        else:
-            return func(match_context, robot_id)
+        return func(match_context)
     return func
 
 def apply_decay(decay_fn, value):
@@ -22,43 +19,6 @@ def apply_decay(decay_fn, value):
     out = decay_fn(abs(value))
 
     return out if value >= 0 else -out
-
-class PotentialDataExporter(object):
-    def __init__(self, name):
-        self.file = open(
-            '{}|potential_field.log'.format(name),
-            'w'
-        )
-
-    def export(self, behaviour, robot, ball):
-        X = []
-        Y = []
-        U = []
-        V = []
-
-        for x in range(-10, 150 + 10, 2):
-            x = x/100.0
-            for y in range(-10, 130 + 10, 2):
-                y = y/100.0
-                res = behaviour.compute([x, y])
-                X.append(x)
-                Y.append(y)
-                U.append(res[0])
-                V.append(res[1])
-
-        plot_file = {
-            "x": X,
-            "y": Y,
-            "u": U,
-            "v": V,
-            "robot_x": robot.x,
-            "robot_y": robot.y,
-            "ball_x": ball.x,
-            "ball_y": ball.y,
-            "behaviour": behaviour.name
-        }
-
-        self.file.write(json.dumps(plot_file) + "||")
 
 class PotentialField(object):
     def __init__(self, match, **kwargs):

--- a/algorithms/potential_fields/plotter.py
+++ b/algorithms/potential_fields/plotter.py
@@ -1,0 +1,38 @@
+import json
+
+class PotentialDataExporter(object):
+    def __init__(self, name):
+        self.file = open(
+            '{}|potential_field.log'.format(name),
+            'w'
+        )
+
+    def export(self, behaviour, robot, ball):
+        X = []
+        Y = []
+        U = []
+        V = []
+
+        for x in range(-10, 150 + 10, 2):
+            x = x/100.0
+            for y in range(-10, 130 + 10, 2):
+                y = y/100.0
+                res = behaviour.compute([x, y])
+                X.append(x)
+                Y.append(y)
+                U.append(res[0])
+                V.append(res[1])
+
+        plot_file = {
+            "x": X,
+            "y": Y,
+            "u": U,
+            "v": V,
+            "robot_x": robot.x,
+            "robot_y": robot.y,
+            "ball_x": ball.x,
+            "ball_y": ball.y,
+            "behaviour": behaviour.name
+        }
+
+        self.file.write(json.dumps(plot_file) + "||")

--- a/config.json
+++ b/config.json
@@ -16,6 +16,6 @@
         "coach_name": "LARC_2020",
         "category": "3v3"
     },
-    "referee": false,
+    "referee": true,
     "data_sender": false
 }

--- a/config.json
+++ b/config.json
@@ -16,6 +16,6 @@
         "coach_name": "LARC_2020",
         "category": "3v3"
     },
-    "referee": true,
+    "referee": false,
     "data_sender": false
 }

--- a/strategy/DebugTools.py
+++ b/strategy/DebugTools.py
@@ -1,0 +1,22 @@
+from strategy.BaseStrategy import Strategy
+
+from algorithms.potential_fields.plotter import PotentialDataExporter
+
+import controller
+
+class DebugPotentialFieldStrategy(Strategy):
+    def __init__(self, match, name, controller=controller.SimpleLQR, controller_kwargs={}):
+        super().__init__(match, name, controller, controller_kwargs)
+        self.analyzed = None
+
+    def start(self, robot=None):
+        super().start(robot)
+        self.exporter = PotentialDataExporter(self.robot.get_name())
+    
+    def decide(self, behaviour):
+        '''
+        recebe o Potential Field para que a analise seja feita e retorna 0, 0
+        '''
+        self.exporter.export(behaviour, self.robot, self.match.ball)
+
+        return [0, 0]

--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -2,3 +2,7 @@ from strategy import tests
 from strategy import larc2020
 from strategy import iron2021
 from strategy.BaseStrategy import Strategy
+
+
+# debug tools
+from strategy import DebugTools


### PR DESCRIPTION
Mais um PR focado em melhorar documentacao e facilitar o desenvolvendo no NeonFC

Dessa vez, transformei o metodo que plota os campos potenciais numa classe abstrata (DebugPotentialFieldStrategy). Dessa forma quem estiver desenvolvendo uma estrategia usando de ```PotentialFields``` podera mudando poucas linhas ter uma visualizacao do seu campo potencial.

Isso foi feito pois se aproximando na LARC esse processo de usar o plotter podera se tornar comum e antes estava muito caixa-preta o uso dele.

E como no PR anterior, essa implementacao vem acompanhada de [uma pagina na wiki](https://github.com/project-neon/NeonFC/wiki/Guia-de-Colaboracao--Criando-um-Atacante) que ensina a montar um atacante basico e tambe a usar essa nova classe de Strategy.