### PR TITLE
stop using replacement file on larc2020 rules

### DIFF
--- a/entities/coach/larc2020.py
+++ b/entities/coach/larc2020.py
@@ -36,7 +36,8 @@ class Coach(BaseCoach):
     def get_positions(self, foul, team_color):
         foul = self.positions.get(foul)
         replacements = foul.get(team_color, foul.get("POSITIONS"))
-        return replacements
+        # FIXME default positions are broken
+        return None
 
     def elect_attacker(self, robot):
         dist_to_ball = math.sqrt(


### PR DESCRIPTION
Como o arquivo ```replacements.json``` esta com as posicoes default erradas, por enquannto removi a chamada desse arquivo na estrategia larc2020. Quando comecarmos a trabalhar com posicionamento de bola parada revisitamos esse arquivo