### PR TITLE
Fix stuck goalkeeper during goalkick

### DIFF
--- a/entities/coach/cbfrs2022_5v5.py
+++ b/entities/coach/cbfrs2022_5v5.py
@@ -23,7 +23,7 @@ class Coach(BaseCoach):
 
         penalty_seconds_trigger = plays.WaitForTrigger(10)
         defendpenalty_seconds_trigger = plays.WaitForTrigger(9)
-        goalkick_seconds_trigger = plays.WaitForTrigger(10)
+        goalkick_seconds_trigger = plays.WaitForTrigger(12)
 
         self.playbook.add_play(main_play)
         self.playbook.add_play(penalty_play)

--- a/entities/plays/cbfrs2022_5v5/goalKickPlay.py
+++ b/entities/plays/cbfrs2022_5v5/goalKickPlay.py
@@ -6,7 +6,7 @@ class GoalKickPlay(MainPlay):
         super().__init__(coach)
 
         self.constraints = [
-            (strategy.cbfrs2022_5v5.GoalKeeper(self.match), self._elect_goalkeeper),
+            (strategy.larc2021.Shooter(self.match), self._elect_goalkeeper),
             (strategy.larc2021.Shooter(self.match), self._elect_leftattacker),
             (strategy.cbfrs2022_5v5.LeftWing(self.match), self._elect_leftwing),
             (strategy.cbfrs2022_5v5.RightWing(self.match), self._elect_rightwing),
@@ -29,8 +29,8 @@ class GoalKickPlay(MainPlay):
                     {
                         "robot_id": 0, 
                         "x": -field_size[0]/2 + 0.1,
-                        "y": 0.2,
-                        "orientation": 60
+                        "y": -0.14,
+                        "orientation": 67
                     }
                 )
             else:
@@ -38,8 +38,8 @@ class GoalKickPlay(MainPlay):
                     {
                         "robot_id": 0, 
                         "x": field_size[0]/2 - 0.1,
-                        "y": 0.2,
-                        "orientation": angle_of_interest
+                        "y": -0.14,
+                        "orientation": 67
                     }
                 )
                 

--- a/entities/plays/cbfrs2022_5v5/goalKickPlay.py
+++ b/entities/plays/cbfrs2022_5v5/goalKickPlay.py
@@ -29,8 +29,8 @@ class GoalKickPlay(MainPlay):
                     {
                         "robot_id": 0, 
                         "x": -field_size[0]/2 + 0.1,
-                        "y": -0.14,
-                        "orientation": 67
+                        "y": 0.2,
+                        "orientation": 60
                     }
                 )
             else:
@@ -38,8 +38,8 @@ class GoalKickPlay(MainPlay):
                     {
                         "robot_id": 0, 
                         "x": field_size[0]/2 - 0.1,
-                        "y": -0.14,
-                        "orientation": 67
+                        "y": 0.2,
+                        "orientation": angle_of_interest
                     }
                 )
                 


### PR DESCRIPTION
Goleiro não estava com estrategia que tirava bola da pequena area.

A solução foi aplicar uma estrategia de `shooter`

Outro problema é que a posição 5v5 da bola durante o tiro de meta esta diferente, sendo agora no meio do gol, a correção tambem considera isso.